### PR TITLE
[Feat] 디자인 수정

### DIFF
--- a/Halmap.xcodeproj/project.pbxproj
+++ b/Halmap.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		F98F622929B4C9BD0025F50E /* Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98F622829B4C9BD0025F50E /* Themes.swift */; };
 		F98F622B29B4CB450025F50E /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98F622A29B4CB450025F50E /* ThemeManager.swift */; };
 		F98F623129B59CE60025F50E /* TeamName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98F623029B59CE60025F50E /* TeamName.swift */; };
+		F98F8D5D29D85B0C00F9C956 /* RequestSongView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98F8D5C29D85B0C00F9C956 /* RequestSongView.swift */; };
 		F9B3B7B529B7397600232BB8 /* MapName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B3B7B429B7397600232BB8 /* MapName.swift */; };
 		F9B3B7B729B842DD00232BB8 /* SongDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B3B7B629B842DD00232BB8 /* SongDetailView.swift */; };
 		F9B95BB928F271A100728048 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B95BB828F271A100728048 /* DataManager.swift */; };
@@ -89,6 +90,7 @@
 		F98F622829B4C9BD0025F50E /* Themes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Themes.swift; sourceTree = "<group>"; };
 		F98F622A29B4CB450025F50E /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		F98F623029B59CE60025F50E /* TeamName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamName.swift; sourceTree = "<group>"; };
+		F98F8D5C29D85B0C00F9C956 /* RequestSongView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestSongView.swift; sourceTree = "<group>"; };
 		F9B3B7B429B7397600232BB8 /* MapName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapName.swift; sourceTree = "<group>"; };
 		F9B3B7B629B842DD00232BB8 /* SongDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongDetailView.swift; sourceTree = "<group>"; };
 		F9B95BB828F271A100728048 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				A81FFC9A28F1778200B0FC7C /* Map */,
 				F91BE5FA29B18AF800F7E488 /* MainTabView.swift */,
 				F91BE5FC29B18D1E00F7E488 /* MainSongListTabView.swift */,
+				F98F8D5C29D85B0C00F9C956 /* RequestSongView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -345,6 +348,7 @@
 				87F6ECF1291677AC004533C4 /* Halmap+UIApplication.swift in Sources */,
 				87F6ECF52916B331004533C4 /* Halmap+UINavigationController.swift in Sources */,
 				A81FFCA528F1B84000B0FC7C /* Halmap+Font.swift in Sources */,
+				F98F8D5D29D85B0C00F9C956 /* RequestSongView.swift in Sources */,
 				A81FFC7C28F15D9900B0FC7C /* ContentView.swift in Sources */,
 				A81FFC9D28F180A000B0FC7C /* SongPlayerView.swift in Sources */,
 				A81FFC8628F15D9C00B0FC7C /* Halmap.xcdatamodeld in Sources */,

--- a/Halmap/Assets.xcassets/Color/TeamColor/SystemColor/mainGreen.colorset/Contents.json
+++ b/Halmap/Assets.xcassets/Color/TeamColor/SystemColor/mainGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7D",
+          "green" : "0xA6",
+          "red" : "0x1D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Halmap/Extensions/Halmap+Color.swift
+++ b/Halmap/Extensions/Halmap+Color.swift
@@ -18,6 +18,7 @@ extension Color {
     static var customDarkGray = Color("customDarkGray")
     static var systemBackground = Color("systemBackground")
     static var tabBarGray = Color("tabBarGray")
+    static var mainGreen = Color("mainGreen")
     
     static func setColor(_ teamName: String) {
         Color.HalmacPoint = Color("\(teamName)Point")

--- a/Halmap/View/CustomTabBar/TabBarItemView.swift
+++ b/Halmap/View/CustomTabBar/TabBarItemView.swift
@@ -19,7 +19,7 @@ struct TabBarItemView: View {
             self.currentTab = tab
         } label: {
             // MARK: - 탭바 형태, 애니메이션
-            VStack {
+            VStack(spacing: 6) {
                 Spacer()
                 Text(tabBarItemName)
                     .font(Font.Halmap.CustomTitleBold)

--- a/Halmap/View/MainSongListTabView.swift
+++ b/Halmap/View/MainSongListTabView.swift
@@ -27,7 +27,7 @@ struct MainSongListTabView: View {
                 Rectangle()
                     .frame(height:UIScreen.getHeight(215))
                     .foregroundColor(Color.HalmacSub)
-                    .edgesIgnoringSafeArea(.all)
+                
                 TabView(selection: $index) {
                     List {
                         ForEach(dataManager.teamSongs) { song in
@@ -80,8 +80,11 @@ struct MainSongListTabView: View {
                     .tag(1)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
-                .padding(.top, -10)
+                .padding(.top, UIScreen.getHeight(27))
+                
+                RequestSongView(buttonColor: Color.HalmacPoint)
             }
+            .edgesIgnoringSafeArea(.top)
             
             //상단 탭바
             TabBarView(currentTab: $index)

--- a/Halmap/View/MainSongListTabView.swift
+++ b/Halmap/View/MainSongListTabView.swift
@@ -23,9 +23,9 @@ struct MainSongListTabView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            VStack {
+            VStack(spacing: 0) {
                 Rectangle()
-                    .frame(height:UIScreen.getHeight(210))
+                    .frame(height:UIScreen.getHeight(215))
                     .foregroundColor(Color.HalmacSub)
                     .edgesIgnoringSafeArea(.all)
                 TabView(selection: $index) {
@@ -80,6 +80,7 @@ struct MainSongListTabView: View {
                     .tag(1)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
+                .padding(.top, -10)
             }
             
             //상단 탭바
@@ -104,6 +105,10 @@ struct MainSongListTabView: View {
                         .padding([.leading, .bottom], 20)
                 }
             }
+            .background(
+                RoundedRectangle(cornerRadius: 12.5)
+                    .fill(Color.HalmacSub)
+            )
             .padding(.top, 70)
         }
         .background(Color.systemBackground)

--- a/Halmap/View/RequestSongView.swift
+++ b/Halmap/View/RequestSongView.swift
@@ -1,0 +1,43 @@
+//
+//  RequestSongView.swift
+//  Halmap
+//
+//  Created by 전지민 on 2023/04/01.
+//
+
+import SwiftUI
+
+struct RequestSongView: View {
+    var buttonColor: Color
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("원하는 응원가가 없으신가요?")
+                .foregroundColor(Color.customDarkGray)
+                .font(Font.Halmap.CustomCaptionMedium)
+            
+            Link(destination: URL(string: "https://forms.gle/KmJaL1UTYahUVGkk7")!) {
+                HStack(spacing: 8) {
+                    Image(systemName: "paperplane.fill")
+                    Text("응원가 신청하기")
+                        .font(Font.Halmap.CustomBodyBold)
+                }
+                .padding(EdgeInsets(top: 8, leading: 38, bottom: 8, trailing: 38))
+                .foregroundColor(buttonColor)
+            }
+            .background {
+                RoundedRectangle(cornerRadius: 18)
+                    .strokeBorder(buttonColor, lineWidth: 1)
+            }
+
+        }
+        .padding(.vertical, 40)
+
+    }
+}
+
+struct RequestSongView_Previews: PreviewProvider {
+    static var previews: some View {
+        RequestSongView(buttonColor: Color.HalmacPoint)
+    }
+}

--- a/Halmap/View/RequestSongView.swift
+++ b/Halmap/View/RequestSongView.swift
@@ -24,12 +24,11 @@ struct RequestSongView: View {
                 }
                 .padding(EdgeInsets(top: 8, leading: 38, bottom: 8, trailing: 38))
                 .foregroundColor(buttonColor)
+                .background {
+                    RoundedRectangle(cornerRadius: 18)
+                        .strokeBorder(buttonColor, lineWidth: 1)
+                }
             }
-            .background {
-                RoundedRectangle(cornerRadius: 18)
-                    .strokeBorder(buttonColor, lineWidth: 1)
-            }
-
         }
         .padding(.vertical, 40)
 

--- a/Halmap/View/SongInformation/SongDetailView.swift
+++ b/Halmap/View/SongInformation/SongDetailView.swift
@@ -32,7 +32,7 @@ struct SongDetailView: View {
                 }
                 Spacer()
                 Rectangle()
-                    .frame(height: 40)
+                    .frame(height: 120)
                     .background(Color.fetchBottomGradient())
                     .foregroundColor(Color(UIColor.clear))
                 ZStack(alignment: .center) {

--- a/Halmap/View/SongInformation/SongPlayerView.swift
+++ b/Halmap/View/SongInformation/SongPlayerView.swift
@@ -56,7 +56,7 @@ struct SongPlayerView: View {
                     //이전곡 재생 기능
                 } label: {
                     Image(systemName: "backward.end.fill")
-                        .font(.system(size: 30, weight: .regular))
+                        .font(.system(size: 28, weight: .regular))
                         .foregroundColor(.customGray)
                 }
 
@@ -69,7 +69,7 @@ struct SongPlayerView: View {
                     }
                 } label: {
                     Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                        .font(.system(size: 50, weight: .medium))
+                        .font(.system(size: 60, weight: .medium))
                         .foregroundColor(.customGray)
                 }
                 
@@ -77,7 +77,7 @@ struct SongPlayerView: View {
                     //다음곡 재생 기능
                 } label: {
                     Image(systemName: "forward.end.fill")
-                        .font(.system(size: 30, weight: .regular))
+                        .font(.system(size: 28, weight: .regular))
                         .foregroundColor(.customGray)
                 }
             }

--- a/Halmap/View/SongSearchView.swift
+++ b/Halmap/View/SongSearchView.swift
@@ -16,6 +16,7 @@ struct SongSearchView: View {
     
     @GestureState private var dragOffset = CGSize.zero
     @FocusState private var isFocused: Bool
+    @State private var isKeyboardFocused = false
     
     @State private var searchText = ""
     @State private var autoComplete = [Song]()
@@ -38,13 +39,18 @@ struct SongSearchView: View {
         .background(Color.systemBackground)
         .navigationBarBackButtonHidden(true)
         .onAppear { UIApplication.shared.hideKeyboard() }
+        .onChange(of: isFocused) { newValue in
+            withAnimation {
+                isKeyboardFocused = newValue
+            }
+            
+        }
     }
     
     
     // MARK: Search Bar
     var searchBar: some View {
         HStack {
-            
             TextField("\(Image(systemName: "magnifyingglass")) 검색", text: $searchText)
                 .accentColor(.black)
                 .disableAutocorrection(true)
@@ -133,11 +139,9 @@ struct SongSearchView: View {
         HStack(spacing: 17) {
             searchBar
             
-            if isFocused == true {
+            if isKeyboardFocused == true {
                 Button {
-                    withAnimation {
-                        isFocused = false
-                    }
+                    isFocused = false
                 } label: {
                     Text("취소")
                 }

--- a/Halmap/View/SongSearchView.swift
+++ b/Halmap/View/SongSearchView.swift
@@ -106,7 +106,6 @@ struct SongSearchView: View {
                             .padding(30)
                         Spacer()
                         RequestSongView(buttonColor: Color.mainGreen)
-                            .background(Color.red)
                     }
                     .frame(maxWidth: .infinity)
                 } else {

--- a/Halmap/View/SongSearchView.swift
+++ b/Halmap/View/SongSearchView.swift
@@ -29,11 +29,10 @@ struct SongSearchView: View {
             
             Divider()
                 .foregroundColor(.customGray)
-                .padding(.top, 20)
+                .padding(.top, 22)
 
             resultView
             
-            Spacer()
         }
         .frame(maxWidth: .infinity)
         .background(Color.systemBackground)
@@ -83,9 +82,9 @@ struct SongSearchView: View {
     // MARK: Result View
     var resultView: some View {
         
-        VStack {
+        VStack(spacing: 0) {
             if searchText.isEmpty {
-                VStack {
+                VStack(spacing: 0) {
                     Text("선수 이름, 응원가를 검색해주세요")
                         .foregroundColor(Color.customDarkGray)
                         .padding(30)
@@ -94,30 +93,40 @@ struct SongSearchView: View {
                 .frame(maxWidth: .infinity)
             } else {
                 
-                List {
-                    ForEach(autoComplete.indices, id: \.self) { index in
-                        NavigationLink(destination: SongDetailView(song: autoComplete[index])) {
-                            HStack {
-                                Image(systemName: "magnifyingglass")
-                                Text(autoComplete[index].title)
-                            }
-                            .font(Font.Halmap.CustomBodyMedium)
-                            .foregroundColor(Color.black)
-                            .frame(height: 45)
-                        }
-                        .listRowBackground(Color(UIColor.clear))
-                        .listRowInsets((EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)))
-                        .listRowSeparatorTint(Color.customGray)
+                if autoComplete.isEmpty {
+                    VStack(spacing: 0) {
+                        Text("검색 결과가 없어요")
+                            .foregroundColor(Color.customDarkGray)
+                            .padding(30)
+                        Spacer()
+                        RequestSongView(buttonColor: Color.mainGreen)
+                            .background(Color.red)
                     }
+                    .frame(maxWidth: .infinity)
+                } else {
+                    List {
+                        ForEach(autoComplete.indices, id: \.self) { index in
+                            NavigationLink(destination: SongDetailView(song: autoComplete[index])) {
+                                HStack {
+                                    Image(systemName: "magnifyingglass")
+                                    Text(autoComplete[index].title)
+                                }
+                                .font(Font.Halmap.CustomBodyMedium)
+                                .foregroundColor(Color.black)
+                                .frame(height: 45)
+                            }
+                            .listRowBackground(Color(UIColor.clear))
+                            .listRowInsets((EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)))
+                            .listRowSeparatorTint(Color.customGray)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .listStyle(.plain)
+                    Spacer()
                 }
-                .padding(.horizontal, 20)
-                .listStyle(.plain)
-                .padding(.top, 10)
-                
             }
         }
         .background(Color.systemBackground)
-        
     }
     
     var navigationView: some View {


### PR DESCRIPTION
### Key changes
- 메인화면 팀 변경 버튼 백그라운드 설정
- 메인화면 응원가 리스트와 팀 변경 버튼 사이의 여백 제거
- 응원가 신청하기 버튼
- 응원가 검색창 애니메이션 추가
- 응원가 재생화면 하단 버튼 크기 수정
- 응원가 재생화면 하단 그라데이션 범위 수정


### Preview
- 팀 변경 버튼 백그라운드 및 응원가 리스트와의 여백 제거

https://user-images.githubusercontent.com/41153398/229293885-20d6f554-e536-4f7a-8798-faa114789612.mp4

- 응원가 신청하기 버튼 기능 및 검색창 애니메이션

https://user-images.githubusercontent.com/41153398/229295533-c26932e5-9be0-4fd4-8143-0b475ba93ca1.mp4


- 응원가 하단 버튼 크기 및 그라데이션 영역

<img src ="https://user-images.githubusercontent.com/41153398/229293992-98a25b4c-48f6-4dbd-9763-b08c51a4a492.png" width=300>



