### PR TITLE
[Feat] 미디어 플레이어와 뷰 연결

### DIFF
--- a/Halmap/Data/AudioManager.swift
+++ b/Halmap/Data/AudioManager.swift
@@ -10,9 +10,10 @@ import Foundation
 import Combine
 import MediaPlayer
 
-final class AudioManager: ObservableObject {
+final class AudioManager: NSObject, ObservableObject {
     static let instance = AudioManager()
     var player: AVPlayer?
+    var item: AVPlayerItem?
 
     @Published private(set) var isPlaying: Bool = false {
         didSet{
@@ -24,6 +25,10 @@ final class AudioManager: ObservableObject {
     var currentProgressPublisher: PassthroughSubject<Float, Never> = .init()
     private var playerPeriodicObserver: Any?
     
+    private var playerItemContext = 0
+    
+    var song: Song?
+    var selectedTeam = ""
 
     // MARK: - Media Player Setting..
     
@@ -77,12 +82,17 @@ final class AudioManager: ObservableObject {
     }
     
     func AMset(song: Song, selectedTeam: String) {
-        let title = song.title
-        let albumArt = UIImage(named: "\(selectedTeam)Album")
-        setupNowPlayingInfo(title: title, albumArt: albumArt)
-
+        
+        self.song = song
+        self.selectedTeam = selectedTeam
+        
         guard let url = URL(string: song.url) else { fatalError("url을 변환할 수 없습니다.") }
-        let item = AVPlayerItem(url: url)
+        self.item = AVPlayerItem(url: url)
+        
+        self.item?.addObserver(self as NSObject,
+                                   forKeyPath: #keyPath(AVPlayerItem.status),
+                                   options: [.old, .new],
+                                   context: &playerItemContext)
         
         player = AVPlayer(playerItem: item)
         
@@ -143,5 +153,62 @@ final class AudioManager: ObservableObject {
     
     private func AMcalculateProgress(currentTime: Double) -> Float {
         return Float(currentTime / AMduration)
+    }
+    
+    //시작 상태 감지를 위한 observer -> 음원이 준비 된 경우 미디어 플레이어 셋팅
+    override func observeValue(forKeyPath keyPath: String?,
+                               of object: Any?,
+                               change: [NSKeyValueChangeKey : Any]?,
+                               context: UnsafeMutableRawPointer?) {
+
+        // Only handle observations for the playerItemContext
+        guard context == &playerItemContext else {
+            super.observeValue(forKeyPath: keyPath,
+                               of: object,
+                               change: change,
+                               context: context)
+            return
+        }
+
+        if keyPath == #keyPath(AVPlayerItem.status) {
+            let status: AVPlayerItem.Status
+            if let statusNumber = change?[.newKey] as? NSNumber {
+                status = AVPlayerItem.Status(rawValue: statusNumber.intValue)!
+            } else {
+                status = .unknown
+            }
+
+            // Switch over status value
+            switch status {
+            case .readyToPlay:
+                // Player item is ready to play.
+                let title = song?.title ?? "unknown title"
+                let albumArt = UIImage(named: "\(selectedTeam)Album")
+                self.setupNowPlayingInfo(title: title, albumArt: albumArt)
+                
+                break
+            case .failed:
+                // Player item failed. See error.
+                print("failed")
+                break
+            case .unknown:
+                // Player item is not yet ready.
+                print("unknown")
+                break
+            @unknown default:
+                print("default")
+                break
+            }
+        }
+    }
+    
+    func removePlayer() {
+        AMstop()
+        player = nil
+        
+        self.item?.removeObserver(self as NSObject,
+                                  forKeyPath: #keyPath(AVPlayerItem.status),
+                                  context: &playerItemContext)
+        
     }
 }

--- a/Halmap/HalmapApp.swift
+++ b/Halmap/HalmapApp.swift
@@ -23,6 +23,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct HalmapApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
+    @StateObject var audioManager = AudioManager()
+    
     let persistenceController = PersistenceController.shared
     
     init() {
@@ -59,8 +61,10 @@ struct HalmapApp: App {
                 OnBoardingStartView()
                     .scrollContentBackground(.hidden)
                     .scrollIndicators(.hidden)
+                    .environmentObject(audioManager)
             } else {
                 OnBoardingStartView()
+                    .environmentObject(audioManager)
             }
         }
     }

--- a/Halmap/View/SongInformation/SongPlayerView.swift
+++ b/Halmap/View/SongInformation/SongPlayerView.swift
@@ -20,7 +20,6 @@ struct SongPlayerView: View {
     let timer = Timer
         .publish(every: 0.3, on: .main, in: .common)
         .autoconnect()
-    @State var isPlaying: Bool = true
     @State var value: Double = 0.0
     @State var isEditing: Bool = false
     @EnvironmentObject var audioManager: AudioManager
@@ -61,14 +60,13 @@ struct SongPlayerView: View {
                 }
 
                 Button {
-                    isPlaying.toggle()
-                    if isPlaying {
-                        AudioManager.instance.AMplay(song: song, selectedTeam: selectedTeam)
+                    if !audioManager.isPlaying {
+                        audioManager.AMplay()
                     } else {
-                        AudioManager.instance.AMstop()
+                        audioManager.AMstop()
                     }
                 } label: {
-                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: audioManager.isPlaying ? "pause.circle.fill" : "play.circle.fill")
                         .font(.system(size: 60, weight: .medium))
                         .foregroundColor(.customGray)
                 }
@@ -87,16 +85,17 @@ struct SongPlayerView: View {
         .frame(maxWidth: .infinity)
         .background(Color.HalmacSub)
         .onDisappear(){
-            AudioManager.instance.AMstop()
+            audioManager.AMstop()
+            audioManager.player = nil
         }
         .onAppear(){
-            AudioManager.instance.AMplay(song: song, selectedTeam: selectedTeam)
+            audioManager.AMset(song: song, selectedTeam: selectedTeam)
         }
         .onReceive(timer) { _ in
             guard let player = AudioManager.instance.player else { return }
             guard let item = AudioManager.instance.player?.currentItem else { return }
             if CMTimeGetSeconds(player.currentTime()) == item.duration.seconds {
-                isPlaying = false
+//                isPlaying = false
             }
             //              value = CMTimeGetSeconds(player.currentTime())
         }

--- a/Halmap/View/SongInformation/SongPlayerView.swift
+++ b/Halmap/View/SongInformation/SongPlayerView.swift
@@ -85,8 +85,7 @@ struct SongPlayerView: View {
         .frame(maxWidth: .infinity)
         .background(Color.HalmacSub)
         .onDisappear(){
-            audioManager.AMstop()
-            audioManager.player = nil
+            audioManager.removePlayer()
         }
         .onAppear(){
             audioManager.AMset(song: song, selectedTeam: selectedTeam)


### PR DESCRIPTION
### Issue
- SongPlayerView와 미디어 플레이어의 재생/정지 기능이 별개로 동작하는 문제 해결

### Key Changes
- SongPlayerView와 미디어 플레이어의 재생/정지 기능 연결
- 재생/정지 기능은 일시정지/멈춘부분에서 다시 재생 기능으로 통일
- 음원이 끝까지 재생되는 경우 시점을 0.0으로 초기화


### To Reviewers
미디어 플레이어의 재생바가 제대로 불러와지지 않았던 문제는 player에 제대로 값이 불러와지지 않았을 때 미디어 플레이어를 세팅해서 발생하는 문제로 확인되었습니다. 현재는 

- 미디어 플레이어 재생바 관련해서 KVO를 추가해서 readyToPlay상태일 때 setupNowPlayingInfo()를 실행하도록 하는 방식
을 사용하여 해결했습니다. 혹시 더 좋은 방법이 존재한다면 알려주세요..!

현재는 응원가 재생 화면에서 메인화면으로 돌아가는 경우에도 미디어 플레이어가 나타나있는 상태입니다. 이것을 응원가 재생 화면 이외의 화면에서는 없어지도록 해야하는지 궁금합니다.
