### PR TITLE
[Fix] 네비게이션 팝 수정

### DIFF
--- a/Halmap/View/MainTabView.swift
+++ b/Halmap/View/MainTabView.swift
@@ -36,6 +36,7 @@ struct MainTabView: View {
             }
             .accentColor(Color.HalmacPoint)
         }
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/Halmap/View/SongInformation/SongContentView.swift
+++ b/Halmap/View/SongInformation/SongContentView.swift
@@ -23,7 +23,7 @@ struct SongContentView: View {
                     .font(.Halmap.CustomHeadline)
                     .lineSpacing(20)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(EdgeInsets(top: 40, leading: 40, bottom: 120, trailing: 40))
+                .padding(EdgeInsets(top: 40, leading: 40, bottom: 200, trailing: 40))
             }
             .background(GeometryReader{
                 Color.clear.preference(key: ViewOffsetKey.self,
@@ -31,9 +31,13 @@ struct SongContentView: View {
             })
             .onPreferenceChange(ViewOffsetKey.self) {
                 if $0 > 0 {
-                    isScrolled = true
+                    withAnimation {
+                        isScrolled = true
+                    }
                 } else {
-                    isScrolled = false
+                    withAnimation {
+                        isScrolled = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Issue
- iOS 15.5버전에서 응원가 재생 화면 접근 시 화면이 바로 dismiss되는 문제 발생


### Key Changes
- navigationViewStyle을 스택으로 지정하여 문제 해결
- 응원가 가사가 하단 그라디언트 위까지 오도록 수정
- 응원가 가사 스크롤 시 상단 그라디언트 생성, 삭제에 애니메이션 추가

### Previews
https://user-images.githubusercontent.com/41153398/232234695-eb2f3a50-d33d-4886-b54e-4f32f0e0dc9d.mp4

<img src ="https://user-images.githubusercontent.com/41153398/232234733-1bf64014-dd80-464f-be96-37abf7532943.png" width=300>



### To Reviewers
- 혹시 아직 반영이 안된 사항이 있다면 알려주세요!
- iPhone SE에서는 가사 마지막줄과 하단 그라디언트가 약간 겹치는 문제 존재합니다.. (기기대응 필요합니다..)
