### PR TITLE
[Fix] #129 observer 해제 시점 변경

### DIFF
--- a/Halmap/Data/AudioManager.swift
+++ b/Halmap/Data/AudioManager.swift
@@ -224,11 +224,6 @@ final class AudioManager: NSObject, ObservableObject {
     }
     func removePlayer() {
         AMstop()
-        player = nil
-        
-        self.item?.removeObserver(self as NSObject,
-                                  forKeyPath: #keyPath(AVPlayerItem.status),
-                                  context: &playerItemContext)
     }
     
     //MARK: - progressbar
@@ -267,5 +262,13 @@ final class AudioManager: NSObject, ObservableObject {
             
             updateNowPlayingPlaybackRate()
         }
+    }
+    
+    deinit {
+        player = nil
+        
+        self.item?.removeObserver(self as NSObject,
+                                  forKeyPath: #keyPath(AVPlayerItem.status),
+                                  context: &playerItemContext)
     }
 }


### PR DESCRIPTION
### Issue
- #129 

### Key Changes
- 옵저버 해제 시점 변경

### To Reviewers
- `AMplayEnd()`의 경우, `AudioManager`내부에서만 해제하기 때문에, 따로 수정하지 않았습니다.
- 현재 develop branch에서는 앱이 꺼지는 과정들을 알 수 없습니다. 그래서 bgResizablePlayer 브랜치에서 발견했던 과정들을 기반으로 테스트 진행했습니다.
<img width="473" alt="image" src="https://github.com/Gwamegis/Moya/assets/68676844/c05be56b-9898-46ec-ba6a-73e55a6ba8bf">
