### PR TITLE
#134 [Refactor] Firebase에서 가져온 노래 재생 로직 수정

### DIFF
--- a/Halmap.xcodeproj/project.pbxproj
+++ b/Halmap.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Halmap/Preview Content\"";
 				DEVELOPMENT_TEAM = Y6P5ZFWBM8;
@@ -639,7 +639,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Halmap/Preview Content\"";
 				DEVELOPMENT_TEAM = Y6P5ZFWBM8;
 				ENABLE_PREVIEWS = YES;
@@ -654,7 +654,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Gwamegis.Halmap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Halmap/Assets.xcassets/팀 앨범 커버/NCAlbum.imageset/Contents.json
+++ b/Halmap/Assets.xcassets/팀 앨범 커버/NCAlbum.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "NCAlbum.png",
+      "filename" : "NcAlbum.png",
       "idiom" : "universal",
       "scale" : "1x"
     },


### PR DESCRIPTION
### Issue
- #134 


### Key Changes
- 기존 Firebase에서 발생하는 과도한 대역폭 비용을 해결하기 위해 노래 다운로드 로직을 수정했습니다.
- Firebase에서 가져온 Url을 스트리밍 하는것이 아닌 최초 재생시에만 다운로드, 이후에는 로컬에 저장된 경로를 찾아 재생합니다.

![화면-기록-2023-08-16-오전-4 24 42](https://github.com/Gwamegis/Moya/assets/52993882/e2f66bf8-119c-4cf7-af45-53e4c714c093)


### To Reviewers
- 속도차이는 기존과 크게 달라보이진 않습니다만 자세한건 실제로 테스트를 해봐야 알수 있을거 같아요
- 테스트 할때 모든 노래를 하나씩 다 틀어보면서 최악의 상황도 돌려봐야될거 같습니당

