### PR TITLE
[Feat] playlist viewmodel 제작

### DIFF
--- a/Halmap.xcodeproj/project.pbxproj
+++ b/Halmap.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		20A687E42A711C48005F18FA /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 20A687E32A711C48005F18FA /* FirebaseFirestoreSwift */; };
 		20A687E62A711C48005F18FA /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 20A687E52A711C48005F18FA /* FirebaseRemoteConfig */; };
 		20A687E82A711C48005F18FA /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 20A687E72A711C48005F18FA /* FirebaseStorage */; };
+		8700972B2AF3CA4400B8B003 /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8700972A2AF3CA4400B8B003 /* PlaylistViewModel.swift */; };
 		87F6ECF1291677AC004533C4 /* Halmap+UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6ECF0291677AC004533C4 /* Halmap+UIApplication.swift */; };
 		87F6ECF52916B331004533C4 /* Halmap+UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6ECF42916B331004533C4 /* Halmap+UINavigationController.swift */; };
 		87F6ECF72916BB44004533C4 /* Halmap+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6ECF62916BB44004533C4 /* Halmap+UIView.swift */; };
@@ -71,6 +72,7 @@
 
 /* Begin PBXFileReference section */
 		20317FB128F2CCBB00A30E09 /* TeamChangingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamChangingView.swift; sourceTree = "<group>"; };
+		8700972A2AF3CA4400B8B003 /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		87F6ECF0291677AC004533C4 /* Halmap+UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Halmap+UIApplication.swift"; sourceTree = "<group>"; };
 		87F6ECF42916B331004533C4 /* Halmap+UINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Halmap+UINavigationController.swift"; sourceTree = "<group>"; };
 		87F6ECF62916BB44004533C4 /* Halmap+UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Halmap+UIView.swift"; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				F9CF1FF22AD2B56300A48D5C /* SongDetailView.swift */,
 				F9F0B61B2AED39EF00B23455 /* PlaylistView.swift */,
 				F9CF1FF42AD2B9B000A48D5C /* SongDetailViewModel.swift */,
+				8700972A2AF3CA4400B8B003 /* PlaylistViewModel.swift */,
 			);
 			path = SongDetail;
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 				F9168B2B2A5A81BC00DCF649 /* Notification.swift in Sources */,
 				A81FFC9128F1775000B0FC7C /* SongSearchView.swift in Sources */,
 				F9DB6D1F2A76744A00B9469D /* LaunchScreenView.swift in Sources */,
+				8700972B2AF3CA4400B8B003 /* PlaylistViewModel.swift in Sources */,
 				F9174B2A2A2B2F5F00B1CE87 /* SeasonSong.swift in Sources */,
 				EEBC26A028F1CAE900BD5B3D /* TabBarItemView.swift in Sources */,
 				F95F26C32A4C9BFD00B534EB /* Progressbar.swift in Sources */,

--- a/Halmap/Features/SongDetail/PlaylistView.swift
+++ b/Halmap/Features/SongDetail/PlaylistView.swift
@@ -11,9 +11,7 @@ struct PlaylistView: View {
     
     @AppStorage("selectedTeam") var selectedTeam = "Hanwha"
     @StateObject var viewModel: PlaylistViewModel
-    @Binding var song: SongInfo {
-        didSet { print(song.title) }
-    }
+    @Binding var song: SongInfo
     @Binding var isScrolled: Bool
     
     let persistence = PersistenceController.shared

--- a/Halmap/Features/SongDetail/PlaylistView.swift
+++ b/Halmap/Features/SongDetail/PlaylistView.swift
@@ -9,47 +9,31 @@ import SwiftUI
 
 struct PlaylistView: View {
     
-    @EnvironmentObject var audioManager: AudioManager
     @AppStorage("selectedTeam") var selectedTeam = "Hanwha"
-    @EnvironmentObject var dataManager: DataManager
-    @Binding var song: SongInfo
+    @StateObject var viewModel: PlaylistViewModel
+    @Binding var song: SongInfo {
+        didSet { print(song.title) }
+    }
     @Binding var isScrolled: Bool
-    
     
     let persistence = PersistenceController.shared
     @FetchRequest(entity: CollectedSong.entity(), sortDescriptors: [NSSortDescriptor(keyPath: \CollectedSong.order, ascending: true)], predicate: PlayListFilter(filter: "defaultPlaylist").predicate, animation: .default) private var collectedSongs: FetchedResults<CollectedSong>
-
-    @FetchRequest(entity: CollectedSong.entity(),
-                  sortDescriptors: [
-                    NSSortDescriptor(keyPath: \CollectedSong.id, ascending: true)
-                  ], animation: .default
-    ) private var playListSongs: FetchedResults<CollectedSong>
+    
     var body: some View {
         ZStack{
-            if collectedSongs.count != 0 {
+            if !collectedSongs.isEmpty {
                 List {
                     ForEach(collectedSongs, id: \.self) { playListSong in
-                        
-                        let songInfo = SongInfo(
-                            id: playListSong.id ?? "",
-                            team: playListSong.team ?? "",
-                            type: playListSong.type ,
-                            title: playListSong.title ?? "" ,
-                            lyrics: playListSong.lyrics ?? "",
-                            info: playListSong.info ?? "",
-                            url: playListSong.url ?? ""
-                        )
-                        
-                        PlaylistRow(songInfo: songInfo)
+                        getPlayListRowView(song: playListSong)
                             .onTapGesture {
-                                self.song = song
-                                audioManager.removePlayer()
-                                audioManager.AMset(song: songInfo)
+                                self.song = viewModel.didTappedSongCell(song: playListSong)
                             }
                     }.onDelete { indexSet in
                         persistence.deleteSong(at: indexSet, from: collectedSongs)
                     }.onMove { indexSet, destination  in
-                        persistence.moveDefaultPlaylistSong(from: indexSet, to: destination, based: collectedSongs)
+                        persistence.moveDefaultPlaylistSong(from: indexSet,
+                                                            to: destination,
+                                                            based: collectedSongs)
                     }
                     .listRowBackground(Color.clear)
                     Rectangle().foregroundStyle(Color.clear).frame(height: 50)
@@ -77,18 +61,36 @@ struct PlaylistView: View {
             }
         }
     }
+    
+    @ViewBuilder
+    private func getPlayListRowView(song: CollectedSong) -> some View {
+        HStack{
+            Image(viewModel.getAlbumImage(with: song))
+                .resizable()
+                .frame(width: 40, height: 40)
+                .cornerRadius(8)
+            VStack(alignment: .leading, spacing: 8) {
+                Text(viewModel.getSongTitle(song: song))
+                    .font(Font.Halmap.CustomBodyMedium)
+                    .foregroundStyle(Color.white)
+                Text(viewModel.getSongTitle(song: song))
+                    .font(Font.Halmap.CustomCaptionMedium)
+                    .foregroundStyle(Color.customGray)
+            }.padding(.horizontal, 16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(1)
+            Image(systemName: "text.justify")
+                .frame(width: 18, height: 18)
+                .foregroundStyle(Color.customGray)
+        }
+        .padding(.horizontal, 20) // 40 -> 20 값 조정
+        .frame(height: 50) // 70 -> 50값 조정
+    }
+    
     private struct ViewOffsetKey: PreferenceKey {
         static var defaultValue = CGFloat.zero
         static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
             value += nextValue()
-        }
-    }
-    
-    func findPlayListSong(at offsets: IndexSet) -> CollectedSong {
-        if let index = playListSongs.firstIndex(where: {song.id == $0.id}) {
-            return playListSongs[index]
-        } else {
-            return CollectedSong()
         }
     }
 }
@@ -106,36 +108,6 @@ struct ListBackgroundModifier: ViewModifier {
     }
 }
 
-private struct PlaylistRow: View {
-    
-    @EnvironmentObject var dataManager: DataManager
-    @State var songInfo: SongInfo
-    
-    var body: some View {
-        HStack{
-            Image(dataManager.checkSeasonSong(data: songInfo) ? "\(songInfo.team)23" : "\( songInfo.team)\(songInfo.type ? "Player" : "Album")")
-                .resizable()
-                .frame(width: 40, height: 40)
-                .cornerRadius(8)
-            VStack(alignment: .leading, spacing: 8) {
-                Text(songInfo.title)
-                    .font(Font.Halmap.CustomBodyMedium)
-                    .foregroundStyle(Color.white)
-                Text(TeamName(rawValue: songInfo.team)?.fetchTeamNameKr() ?? ".")
-                    .font(Font.Halmap.CustomCaptionMedium)
-                    .foregroundStyle(Color.customGray)
-            }.padding(.horizontal, 16)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .lineLimit(1)
-            Image(systemName: "text.justify")
-                .frame(width: 18, height: 18)
-                .foregroundStyle(Color.customGray)
-        }
-        .padding(.horizontal, 20) // 40 -> 20 값 조정
-        .frame(height: 50) // 70 -> 50값 조정
-    }
-}
-
-#Preview {
-    PlaylistView(song: .constant(SongInfo(id: "",team: "NC", type: false, title: "test", lyrics: "test", info: "test", url: "test")), isScrolled: .constant(false))
-}
+//#Preview {
+//    PlaylistView(song: .constant(SongInfo(id: "",team: "NC", type: false, title: "test", lyrics: "test", info: "test", url: "test")), isScrolled: .constant(false))
+//}

--- a/Halmap/Features/SongDetail/PlaylistViewModel.swift
+++ b/Halmap/Features/SongDetail/PlaylistViewModel.swift
@@ -11,19 +11,12 @@ final class PlaylistViewModel: ObservableObject {
     
     private let audioManager: AudioManager
     private let dataManager: DataManager
-    
     private var song: SongInfo
     
-    init(audioManager: AudioManager, dataManager: DataManager, song: SongInfo) {
-        self.audioManager = audioManager
-        self.dataManager = dataManager
-        self.song = song
-    }
-    
     init(viewModel: SongDetailViewModel) {
-        self.audioManager = viewModel.audioManager
-        self.dataManager = viewModel.dataManager
-        self.song = viewModel.song
+        audioManager = viewModel.getAudioManager()
+        dataManager = viewModel.getdataManager()
+        song = viewModel.getSongInfo()
     }
     
     func getAlbumImage(with song: CollectedSong) -> String {
@@ -54,11 +47,11 @@ final class PlaylistViewModel: ObservableObject {
     }
     
     private func convertSongToSongInfo(song: CollectedSong) -> SongInfo {
-        return SongInfo(
+        SongInfo(
             id: song.id ?? "",
             team: song.team ?? "",
             type: song.type,
-            title: song.title ?? "" ,
+            title: song.title ?? "",
             lyrics: song.lyrics ?? "",
             info: song.info ?? "",
             url: song.url ?? ""

--- a/Halmap/Features/SongDetail/PlaylistViewModel.swift
+++ b/Halmap/Features/SongDetail/PlaylistViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  PlaylistViewModel.swift
+//  Halmap
+//
+//  Created by 이지원 on 2023/11/02.
+//
+
+import Foundation
+
+final class PlaylistViewModel: ObservableObject {
+    
+    private let audioManager: AudioManager
+    private let dataManager: DataManager
+    
+    private var song: SongInfo
+    
+    init(audioManager: AudioManager, dataManager: DataManager, song: SongInfo) {
+        self.audioManager = audioManager
+        self.dataManager = dataManager
+        self.song = song
+    }
+    
+    init(viewModel: SongDetailViewModel) {
+        self.audioManager = viewModel.audioManager
+        self.dataManager = viewModel.dataManager
+        self.song = viewModel.song
+    }
+    
+    func getAlbumImage(with song: CollectedSong) -> String {
+        let song = convertSongToSongInfo(song: song)
+        if dataManager.checkSeasonSong(data: song) {
+            return "\(song.team)23"
+        } else {
+            return "\(song.team)\(song.type ? "Player" : "Album")"
+        }
+    }
+    
+    func getSongTitle(song: CollectedSong) -> String {
+        song.title ?? ""
+    }
+    
+    func getSongTeamName(with song: CollectedSong) -> String {
+        let song = convertSongToSongInfo(song: song)
+        return TeamName(rawValue: song.team)?.fetchTeamNameKr() ?? "."
+    }
+    
+    func didTappedSongCell(song: CollectedSong) -> SongInfo {
+        let song = convertSongToSongInfo(song: song)
+        print(#function, song.title)
+        self.song = song
+        audioManager.removePlayer()
+        audioManager.AMset(song: song)
+        return song
+    }
+    
+    private func convertSongToSongInfo(song: CollectedSong) -> SongInfo {
+        return SongInfo(
+            id: song.id ?? "",
+            team: song.team ?? "",
+            type: song.type,
+            title: song.title ?? "" ,
+            lyrics: song.lyrics ?? "",
+            info: song.info ?? "",
+            url: song.url ?? ""
+        )
+    }
+}

--- a/Halmap/Features/SongDetail/SongDetailView.swift
+++ b/Halmap/Features/SongDetail/SongDetailView.swift
@@ -20,7 +20,7 @@ struct SongDetailView: View {
             
             if isPlayListView {
                 VStack {
-                    PlaylistView(song: $viewModel.song, isScrolled: $viewModel.isScrolled)
+                    PlaylistView(viewModel: PlaylistViewModel(viewModel: viewModel), song: $viewModel.song, isScrolled: $viewModel.isScrolled)
                         .padding(.top, 10)
                         .padding(.bottom, 150)
                 }

--- a/Halmap/Features/SongDetail/SongDetailViewModel.swift
+++ b/Halmap/Features/SongDetail/SongDetailViewModel.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import Combine
 
 final class SongDetailViewModel: ObservableObject {
-    @ObservedObject var audioManager: AudioManager
-    let dataManager: DataManager
-    let persistence: PersistenceController
+    @ObservedObject private var audioManager: AudioManager
+    private let dataManager: DataManager
+    private let persistence: PersistenceController
     
     @Published var song: SongInfo
     @Published var isScrolled = false
@@ -65,5 +65,18 @@ final class SongDetailViewModel: ObservableObject {
         let collectedSong = persistence.createCollectedSong(song: song, playListTitle: "bufferPlaylist")
         persistence.resetBufferList(song: collectedSong)
         persistence.saveSongs(song: song, playListTitle: "defaultPlaylist")
+    }
+    
+    // MARK: - initailize playlist view model
+    func getAudioManager() -> AudioManager {
+        self.audioManager
+    }
+    
+    func getdataManager() -> DataManager {
+        self.dataManager
+    }
+    
+    func getSongInfo() -> SongInfo {
+        self.song
     }
 }

--- a/Halmap/Features/SongDetail/SongDetailViewModel.swift
+++ b/Halmap/Features/SongDetail/SongDetailViewModel.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import Combine
 
 final class SongDetailViewModel: ObservableObject {
-    @ObservedObject private var audioManager: AudioManager
-    private let dataManager: DataManager
-    private let persistence: PersistenceController
+    @ObservedObject var audioManager: AudioManager
+    let dataManager: DataManager
+    let persistence: PersistenceController
     
     @Published var song: SongInfo
     @Published var isScrolled = false


### PR DESCRIPTION
### Issue
- #145 (뷰모델 태스크)

### To Reviewers
- playListRow를 struct -> 함수로 변경했습니다.
  - playLIstRow를 위한 뷰모델을 전달하거나, 새로 만들어야하는데, viewBuilder로 만들어서 같이 처리하는게 더 좋다고 생각했습니다!
- 해당 뷰 모델이 Song Detail View에서 생성되는데, 접근할 수 있는 audioManager나 dataManager가 없어서 SongDetailViewModel에 새로운 각 객체를 리턴할 수 있는 함수를 제작했습니다.
  - SongDetailViewModel 내부 변수를 private를 빼서 초기화하려고 했는데, 좋은 접근이 아닌 것 같아서 각각 함수로 분리했습니다.
  - 다른 좋은 의견 있으시면 말씀해주세요ㅠ ㅠ  
- #146 기반으로 작업된 내용입니다. (#145-songDetailViewModel 브랜치에 머지하겠습니다)